### PR TITLE
Fix typo in index pages

### DIFF
--- a/docs/index+1.html
+++ b/docs/index+1.html
@@ -127,7 +127,7 @@
         underpinnings of hard technology problems in an industry rooted in data and risk management. We openly discuss
         innovating in the minefield of durable regulation, intense competition and relentless change. In an industry
         where legacy complements modern, resilience meets expertise, and the thankless becomes the celebrated, the
-        future is squarely pegged on wining in and with technology. Let's celebrate the unsung heroes excelling at
+        future is squarely pegged on winning in and with technology. Let's celebrate the unsung heroes excelling at
         insurance technology, where success is anything but ordinary!</p>
     </div>
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -127,7 +127,7 @@
         underpinnings of hard technology problems in an industry rooted in data and risk management. We openly discuss
         innovating in the minefield of durable regulation, intense competition and relentless change. In an industry
         where legacy complements modern, resilience meets expertise, and the thankless becomes the celebrated, the
-        future is squarely pegged on wining in and with technology. Let's celebrate the unsung heroes excelling at
+        future is squarely pegged on winning in and with technology. Let's celebrate the unsung heroes excelling at
         insurance technology, where success is anything but ordinary!</p>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- fix 'wining' typo in index pages

## Testing
- `grep -n winn docs/index.html`


------
https://chatgpt.com/codex/tasks/task_b_6883faa04ecc832da3f12cb37cdb94c6