### PR TITLE
Fix anchor in docs index files

### DIFF
--- a/docs/index+1.html
+++ b/docs/index+1.html
@@ -507,7 +507,7 @@
       </li>
       <li><a href="https://apciaevents.cventevents.com/event/24Annual/summary">APCIA Annual Meeting, 2024</a>
       </li>
-      <li><a href="https://vegas.insuretechconnect.com/2024agenda">ITC Vegas/a>
+      <li><a href="https://vegas.insuretechconnect.com/2024agenda">ITC Vegas</a>
       </li>
       <li><a href="https://connections.guidewire.com/event/ae187895-02d1-4f2a-b509-4f244b468f49">Guidewire
           Connections</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -430,7 +430,7 @@
       </li>
       <li><a href="https://apciaevents.cventevents.com/event/24Annual/summary">APCIA Annual Meeting, 2024</a>
       </li>
-      <li><a href="https://vegas.insuretechconnect.com/2024agenda">ITC Vegas/a>
+      <li><a href="https://vegas.insuretechconnect.com/2024agenda">ITC Vegas</a>
       </li>
       <li><a href="https://connections.guidewire.com/event/ae187895-02d1-4f2a-b509-4f244b468f49">Guidewire
           Connections</a>


### PR DESCRIPTION
## Summary
- close malformed anchor tag for ITC Vegas link in docs

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6883fb3fdfe8832d924de4a6ae002cde