### PR TITLE
Add HTML validation test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install pytest
+        run: pip install pytest
+      - name: Run tests
+        run: pytest
+      - name: Deploy
+        if: ${{ success() }}
+        run: echo "Deploying..."

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Premium Bytes
+
+This repository contains the source files for the Premium Bytes website.
+
+## Running tests
+
+Install Python 3 and run the test suite using:
+
+```bash
+pytest
+```

--- a/tests/test_html_valid.py
+++ b/tests/test_html_valid.py
@@ -1,0 +1,9 @@
+import glob
+from html.parser import HTMLParser
+
+def test_html_files_parse():
+    parser = HTMLParser()
+    for path in glob.glob('docs/*.html'):
+        with open(path, encoding='utf-8') as f:
+            data = f.read()
+        parser.feed(data)


### PR DESCRIPTION
## Summary
- create a simple pytest that parses docs/*.html using `HTMLParser`
- run tests in CI workflow
- document how to run tests with `pytest`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6883fce9c2e0832d8915dfac3fa50076